### PR TITLE
chr 43 setup automatic configuration of rabbitmq objects settings

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -80,13 +80,14 @@ services:
       - 5552:5552
       - 5672:5672
       - 15672:15672
+      - 15692:15692
     environment:
       RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: "-rabbitmq_stream advertised_host localhost"
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
-      # TODO: enable support for configuring default plugins
-      #- enabled_plugins:/etc/rabbitmq/enabled_plugins
-      # TODO: setup default schema for queues, exchangesm and bindins using defs.json
+      - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
+      - ./rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins
+      - ./rabbitmq/defs.json:/etc/rabbitmq/defs.json
 
 volumes:
   db-data:

--- a/rabbitmq/enabled_plugins
+++ b/rabbitmq/enabled_plugins
@@ -1,1 +1,1 @@
-[rabbitmq_federation, rabbitmq_management, rabbitmq_management_agent, rabbitmq_mqtt]
+[rabbitmq_prometheus,rabbitmq_federation,rabbitmq_management,rabbitmq_management_agent,rabbitmq_web_dispatch,rabbitmq_mqtt].

--- a/rabbitmq/rabbitmq.conf
+++ b/rabbitmq/rabbitmq.conf
@@ -101,7 +101,7 @@
 ## Related doc guide: https://rabbitmq.com/ssl.html.
 ##
 # listeners.ssl.1                  = 5671
-# 
+#
 # ssl_options.verify               = verify_peer
 # ssl_options.fail_if_no_peer_cert = false
 # ssl_options.cacertfile           = /path/to/cacert.pem
@@ -277,10 +277,12 @@
 ## to be enabled.
 ##
 # load_definitions = /path/to/definitions/file.json
-load_definitions = definitions.json
+# load_definitions = /etc/rabbitmq/defs.json
 definitions.import_backend = local_filesystem
+definitions.local.path = /etc/rabbitmq/defs.json
 definitions.skip_if_unchanged = true
 
+message_interceptors.incoming.set_header_timestamp.overwrite = false
 
 ##
 ## Cluster name
@@ -905,7 +907,7 @@ definitions.skip_if_unchanged = true
 ## Sets the durable queue type to be used for QoS 1 subscriptions.
 ##
 ## Supported types are:
-## 
+##
 ## * classic
 ## * quorum
 ##


### PR DESCRIPTION
This pull request includes several changes to the RabbitMQ configuration in the `compose.yaml` file and related files to improve the setup and management of RabbitMQ services. The most important changes are:

### Configuration Enhancements:

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR83-R90): Added a new port mapping for RabbitMQ (15692:15692) and included additional configuration files for RabbitMQ setup (`rabbitmq.conf`, `enabled_plugins`, and `defs.json`).

### Plugin Management:

* [`rabbitmq/enabled_plugins`](diffhunk://#diff-3400d6cc7a14a2d02a7effa03011d24bd5f8dc0177d0d204be9eca273446ceadL1-R1): Updated the list of enabled RabbitMQ plugins to include `rabbitmq_prometheus` and `rabbitmq_web_dispatch`.

### Definitions and Interceptors:

* [`rabbitmq/rabbitmq.conf`](diffhunk://#diff-747bf1c84578cd87b7a855ef5a0518d89baaa1b66593663d65fa5867892f9817L280-R285): Modified the configuration to correctly reference the `defs.json` file, added a local path for definitions, and introduced a message interceptor setting to handle incoming messages.

### Changelog

- **feat(rabbitmq): add default enabled plugins**
- **feat(rabbitmq): configure load defaults & message timestamp headers**
- **feat(compose): add defaults & configs to docker container rabbitmq**
