### PR TITLE
chr 87 setup grafana prometheus monitoring for infrastructure

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -98,10 +98,19 @@ services:
       - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
       - ./rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins
       - ./rabbitmq/defs.json:/etc/rabbitmq/defs.json
+  prometheus:
+    image: prom/prometheus
+    container_name: pih-prometheus
+    ports:
+      - 9090:9090
+    volumes:
+      - prometheus-data:/prometheus
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
 
 volumes:
   db-data:
   rabbitmq_data:
+  prometheus-data:
   #rabbitmq:
 secrets:
   db-password:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+# prometheus.yml
+
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "pih-core-go"
+    static_configs:
+      - targets: ["localhost:8080"]


### PR DESCRIPTION
This pull request introduces Prometheus monitoring to the project by adding a new service to `compose.yaml` and creating a configuration file for Prometheus. The most important changes include adding Prometheus as a service and defining its configuration.

### Prometheus Integration:

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR101-R113): Added a new Prometheus service with its image, container name, ports, and volumes.
* [`prometheus/prometheus.yml`](diffhunk://#diff-79c19119fd226b897b5aa398c6623a078e9ae00fbd2fe20807e1fbb373fa0294R1-R9): Created a new Prometheus configuration file with global scrape interval and scrape configurations for `pih-core-go`.

### Changeless

- **feat(compose): add prometheus image**
- **feat(prometheus): add configuration file**
