### PR TITLE
chr 87 setup grafana prometheus monitoring for infrastructure

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -98,10 +98,19 @@ services:
       - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
       - ./rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins
       - ./rabbitmq/defs.json:/etc/rabbitmq/defs.json
+  prometheus:
+    image: prom/prometheus
+    container_name: pih-prometheus
+    ports:
+      - 9090:9090
+    volumes:
+      - prometheus-data:/prometheus
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
 
 volumes:
   db-data:
   rabbitmq_data:
+  prometheus-data:
   #rabbitmq:
 secrets:
   db-password:

--- a/compose.yaml
+++ b/compose.yaml
@@ -113,6 +113,12 @@ services:
       - 3000:3000
     volumes:
       - grafana-storage:/var/lib/grafana
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter
+    ports:
+      - 9187:9187
+    environment:
+      - DATA_SOURCE_NAME="postgres://monitoring:pih-admin@host.docker.internal:5439/pih?sslmode=require"
 
 volumes:
   db-data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -106,11 +106,19 @@ services:
     volumes:
       - prometheus-data:/prometheus
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+  grafana:
+    image: grafana/grafana-enterprise
+    container_name: pih-grafana
+    ports:
+      - 3000:3000
+    volumes:
+      - grafana-storage:/var/lib/grafana
 
 volumes:
   db-data:
-  rabbitmq_data:
+  grafana-storage: {}
   prometheus-data:
+  rabbitmq_data:
   #rabbitmq:
 secrets:
   db-password:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -5,16 +5,18 @@ global:
 
 scrape_configs:
   - job_name: prometheus
+    metrics_path: /metrics
     static_configs:
       - targets:
           - "host.docker.internal:9090"
   - job_name: "docker"
+    metrics_path: /metrics
     static_configs:
       - targets:
           - "host.docker.internal:9323"
   - job_name: "pih-core-go"
     static_configs:
-      - targets: ["host.docker.internal:8080"]
+      - targets: ["host.docker.internal:8080", "host.docker.internal:9187"]
   - job_name: "rabbitmq-server"
     static_configs:
       - targets:
@@ -26,3 +28,7 @@ scrape_configs:
     static_configs:
       - targets:
           - "host.docker.internal:15692"
+  - job_name: postgres-exporter
+    # metrics_path: /metrics
+    static_configs:
+      - targets: ["host.docker.internal:9187"]

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+# prometheus.yml
+
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "pih-core-go"
+    static_configs:
+      - targets: ["localhost:8080"]

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -4,6 +4,25 @@ global:
   scrape_interval: 15s
 
 scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - "host.docker.internal:9090"
+  - job_name: "docker"
+    static_configs:
+      - targets:
+          - "host.docker.internal:9323"
   - job_name: "pih-core-go"
     static_configs:
-      - targets: ["localhost:8080"]
+      - targets: ["host.docker.internal:8080"]
+  - job_name: "rabbitmq-server"
+    static_configs:
+      - targets:
+          - "host.docker.internal:15692"
+  - job_name: "rabbitmq-server-detailed"
+    metrics_path: "/metrics/detailed"
+    params:
+      family: ["queue_coarse_metrics"]
+    static_configs:
+      - targets:
+          - "host.docker.internal:15692"


### PR DESCRIPTION
This pull request introduces new services and updates configurations to enhance monitoring and metrics collection. The main changes include adding Grafana and Postgres Exporter services to the `compose.yaml` file and updating the `prometheus.yml` configuration to include new scrape jobs.

New services added:

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR109-R126): Added Grafana service with the image `grafana/grafana-enterprise`, exposing port 3000, and configured volume for storage.
* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR109-R126): Added Postgres Exporter service with the image `quay.io/prometheuscommunity/postgres-exporter`, exposing port 9187, and configured environment variables for data source.

Prometheus configuration updates:

* [`prometheus/prometheus.yml`](diffhunk://#diff-79c19119fd226b897b5aa398c6623a078e9ae00fbd2fe20807e1fbb373fa0294R7-R34): Added scrape job for Prometheus with metrics path `/metrics` and target `host.docker.internal:9090`.
* [`prometheus/prometheus.yml`](diffhunk://#diff-79c19119fd226b897b5aa398c6623a078e9ae00fbd2fe20807e1fbb373fa0294R7-R34): Added scrape job for Docker with metrics path `/metrics` and target `host.docker.internal:9323`.
* [`prometheus/prometheus.yml`](diffhunk://#diff-79c19119fd226b897b5aa398c6623a078e9ae00fbd2fe20807e1fbb373fa0294R7-R34): Added scrape job for Postgres Exporter with target `host.docker.internal:9187`.

### Changelist

- **feat(compose): add prometheus image**
- **feat(prometheus): add configuration file**
- **feat(compose): add grafana container**
- **feat(prometheus): add metrics collection for rabbitmq, docker, and prometheus**
- **feat(compose): add postgres-exporter**
- **feat(prometheus): add configurations for postgres-exporter**
