### PR TITLE
feat: setup minio bucket storage in compose project

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -119,14 +119,40 @@ services:
       - 9187:9187
     environment:
       - DATA_SOURCE_NAME="postgres://monitoring:pih-admin@host.docker.internal:5439/pih?sslmode=require"
+  minio:
+    image: minio/minio
+    container_name: minio
+    environment:
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
+      - MINIO_DOMAIN=minio
+    ports:
+      - 9000:9000
+      - 9001:9001
+    command: ["server", "/data", "--console-address", ":9001"]
+  mc:
+    depends_on:
+      - minio
+    image: minio/mc
+    container_name: mc
+    environment:
+      - AWS_ACCESS_KEY_ID=admin
+      - AWS_SECRET_ACCESS_KEY=password
+      - AWS_REGION=us-east-1
+    entrypoint: >
+      /bin/sh -c "
+      until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      /usr/bin/mc rm -r --force minio/warehouse;
+      /usr/bin/mc mb minio/warehouse;
+      /usr/bin/mc policy set public minio/warehouse
+      tail -f /dev/null
+      "
 
 volumes:
   db-data:
   grafana-storage: {}
   prometheus-data:
   rabbitmq_data:
-  prometheus-data:
-  #rabbitmq:
 secrets:
   db-password:
     file: db/password.txt


### PR DESCRIPTION
This adds bucket storage infrastructure in the form of minio to the project. It can/will be used for raw data storage, as well as the storage backend for the eventual (if needed) iceberg catalog.